### PR TITLE
updates close btn markup to reflect requirements to close

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -113,7 +113,7 @@
   <div class="modal" id="modal" tabindex="-1" role="dialog">
     <div class="modal-container">
       <div class="modal-close">
-        <a href="#" id="close-modal">
+        <a href="#" data-dismiss="modal" aria-label="Close">
          Close
         </a>
       </div>
@@ -141,7 +141,7 @@
   <div class="modal" id="modalChart" tabindex="-1" role="dialog">
     <div class="modal-container">
       <div class="modal-close">
-        <a href="#" id="close-modal">
+        <a href="#" data-dismiss="modal" aria-label="Close">
          Close
         </a>
       </div>


### PR DESCRIPTION
Simple fix for closing modals. We're using bootstrap JS functionality. We just needed proper markup for closing modals.

fixes #58