### PR TITLE
Remove modal from text card in sidebar

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -64,7 +64,7 @@
       <div class="sidebar--inner">
 
         <!-- Card of content -->
-        <div class="card" data-target="#modalChart" data-toggle="modal">
+        <div class="card">
           <div class="card--inner">
             <!-- Content of cards needs to fall inside
             of the .card-list > li -->


### PR DESCRIPTION
Had an end of day discussion with DA about removing the modal functionality from all the sidebar cards. This does that. We're keeping the "Learn More" to show help text.

@designmatty feel free to merge if looks good, then merge your PR