### PR TITLE
Correctly reset zoom to national level on census popup click

### DIFF
--- a/app/assets/js/src/main.js
+++ b/app/assets/js/src/main.js
@@ -54,7 +54,7 @@ $(document).ready(function() {
         setChangeChart(msaId);
 
         // Auto zoom map to selected MSA, or zoom out if National Average selected
-        if (msaId === 'NNNNN') {
+        if (msaId === TCVIZ.Config.defaultMSA) {
             map.setView(TCVIZ.Config.map.center, TCVIZ.Config.map.zoom);
         } else {
             TCVIZ.Connections.msaMap.getBBoxForMSA(msaId).done(function(bbox) {
@@ -82,8 +82,8 @@ $(document).ready(function() {
     });
 
     $('body').on('click', '#tract-popup-zoom', function() {
+        // Toggle change handles map zoom
         msaToggle.setValue(TCVIZ.Config.defaultMSA);
-        map.setZoom(TCVIZ.Config.zoomThreshold);
     });
 
     map.on('zoomstart', onZoomStart);
@@ -172,7 +172,7 @@ $(document).ready(function() {
         setUpEventListeners();
         setMapDropdownValue();
         setMap();
-        setChangeChart('NNNNN');
+        setChangeChart(TCVIZ.Config.defaultMSA);
 
         function setUpEventListeners() {
             setUpSidebarToggle();


### PR DESCRIPTION
## Notes

Also updates hardcoded strings to TCVIZ.Config.defaultMSA where
appropriate.

## Testing
- Click a popup at the national level, then the "See MSA Census Details" link. Then click a census tract once the layer loads, and then then "See MSA Transit Details" link. The map should properly zoom in and out again to the same national view as you click the links.

Closes #61 