### PR TITLE
Add correct name attribute for MSA popup

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -164,7 +164,7 @@
   <!-- templates -->
   <script id="msa-popup-tmpl" type="text/template">
     <div id="msa-popup">
-        <h4><%= name %></h4>
+        <h4><%= name_ms %></h4>
         <div>
             <label>2015 Annual Ridership</label>
             <div><%= upt_total_y15.toLocaleString() %></div>


### PR DESCRIPTION
# Overview
The name was referencing an old table version and was not showing up as the title of the popup.

## Demo
![screenshot from 2017-11-09 08 33 07](https://user-images.githubusercontent.com/1014341/32607983-b447e6b4-c528-11e7-8c86-6b3e5f91bbf4.png)

## Testing
Click an MSA circle and confirm the name is displayed in the header `h4` element.