### PR TITLE
Refactor map zoom/pan/state logic in main.js

### DIFF
--- a/app/assets/js/src/main.js
+++ b/app/assets/js/src/main.js
@@ -17,8 +17,7 @@ $(document).ready(function() {
     var layerToggle = null;
     var msaToggle = null;
     var ridershipChartToggle = null;
-    var featureGroup = {};
-    var nationWide = isNationWide();
+    var featureGroup = null;
 
     /*
      Initialize objects
@@ -59,25 +58,28 @@ $(document).ready(function() {
     Listeners
      */
     layerToggle.on('change', function() {
-        setMap();
-        setLegend(layerToggle.getValue());
+        setMap(msaToggle.getValue(), layerToggle.getValue());
     });
     msaToggle.on('change', function() {
         var msaId = msaToggle.getValue();
-        setRidershipChart(msaId, TCVIZ.Config.ridershipChartLeftAxisDefault, ridershipChartToggle.getValue());
+
+        // Updates layer toggle which triggers map layer updates
+        updateMapDropdown();
+
+        setRidershipChart(
+            msaId,
+            TCVIZ.Config.ridershipChartLeftAxisDefault,
+            ridershipChartToggle.getValue());
         setChangeChart(msaId);
 
         // Auto zoom map to selected MSA, or zoom out if National Average selected
-        if (msaId === TCVIZ.Config.defaultMSA) {
+        if (isNationWide()) {
             map.setView(TCVIZ.Config.map.center, TCVIZ.Config.map.zoom);
         } else {
             TCVIZ.Connections.msaMap.getBBoxForMSA(msaId).done(function(bbox) {
                 map.fitBounds(bbox);
             });
         }
-
-        setLegend(msaId);
-        // TODO: May need to readd setMap() call here
     });
     ridershipChartToggle.on('change', function(value) {
         var msaId = msaToggle.getValue();
@@ -101,9 +103,6 @@ $(document).ready(function() {
         msaToggle.setValue(TCVIZ.Config.defaultMSA);
     });
 
-    map.on('zoomstart', onZoomStart);
-    map.on('zoomend', onZoomEnd);
-
     /*
     Functions--------------------------------------------------------------
      */
@@ -114,7 +113,7 @@ $(document).ready(function() {
      * @param  {Array}
      */
     function changeToggle(select, layer_options) {
-        select.clear();
+        select.clear(true);     // Do not fire change event when cleared
         select.clearOptions();
         select.addOption(layer_options);
     }
@@ -154,15 +153,6 @@ $(document).ready(function() {
     }
 
     /**
-     * Determine whether the app is zoomed out beyond nationwide
-     * mapping threshhold
-     * @return {Boolean}
-     */
-    function isNationWide() {
-        return (map.getZoom() <= TCVIZ.Config.zoomThreshold);
-    }
-
-    /**
      * Initialize app
      */
     function initialize() {
@@ -172,10 +162,10 @@ $(document).ready(function() {
          */
         setUpSelectize();
         setUpEventListeners();
-        setMapDropdownValue();
-        setMap();
-        setLegend(TCVIZ.Config.defaultNtdField);
+        updateMapDropdown();
 
+        setMap(TCVIZ.Config.defaultMSA, TCVIZ.Config.defaultNtdField);
+        setLegend(TCVIZ.Config.defaultNtdField);
         setChangeChart(TCVIZ.Config.defaultMSA);
         setRidershipChart(
             msaToggle.getValue(),
@@ -221,7 +211,6 @@ $(document).ready(function() {
                 ]
             }));
             ridershipChartToggle = $('#selectize-ridership-chart')[0].selectize;
-            //ridershipChartToggle.setValue(TCVIZ.Config.ridershipChartRightAxisDefault);
         }
 
         function setUpSidebarToggle() {
@@ -229,34 +218,6 @@ $(document).ready(function() {
                 el.preventDefault();
                 $('.sidebar').toggleClass('active');
             });
-        }
-    }
-
-    /**
-     * React to start of change in zoom level, set state boolean
-     * variable indicating whether the zoom started above or below
-     * the zoom threshold
-     */
-    function onZoomStart() {
-        TCVIZ.State.startNationWide = isNationWide();
-    }
-
-    /**
-     * React to end zoom level, changing the map content if threshold was
-     * passed
-     */
-    function onZoomEnd() {
-        nationWide = isNationWide();
-        if (TCVIZ.State.startNationWide !== nationWide) {
-            if (nationWide) {
-                changeToggle(layerToggle, TCVIZ.Config.nationwide_layers);
-                setMapDropdownValue();
-                TCVIZ.State.ntdField = layerToggle.items[0];
-            } else {
-                changeToggle(layerToggle, TCVIZ.Config.MSA_layers);
-                setMapDropdownValue();
-                TCVIZ.State.censusField = layerToggle.items[0];
-            }
         }
     }
 
@@ -273,11 +234,11 @@ $(document).ready(function() {
     /**
      * Send a layer to the map calling function based on map zoom
      */
-    function setMap() {
+    function setMap(msaId, layerId) {
         if (isNationWide()) {
-            setNationalGeoJSONLayer();
+            setNationalGeoJSONLayer(layerId);
         } else {
-            setMSAGeoJSONLayer();
+            setMSAGeoJSONLayer(msaId, layerId);
         }
     }
 
@@ -333,87 +294,82 @@ $(document).ready(function() {
     /**
      * Set polygon layer of MSAs
      */
-    function setMSAGeoJSONLayer() {
-        var valueField = layerToggle.items[0];
-        var msaId = msaToggle.items[0];
-        if (valueField !== undefined) {
-            if (map.hasLayer(featureGroup)) {
-                map.removeLayer(featureGroup);
-            }
-            TCVIZ.State.censusField = valueField;
-            TCVIZ.Connections.tractMap.getJson(valueField, msaId)
-                .done(function(data) {
-                    data = removeNAs(data, valueField);
-                    featureGroup = L.geoJson(data, {
-                        style: function(feature) {
-                            return stylePolygons(feature, valueField);
-                        }
-                    });
-                    map.addLayer(featureGroup);
+    function setMSAGeoJSONLayer(msaId, layerId) {
+        if (!layerId) { return; }
+        var valueField = layerId;
 
-                    featureGroup.on('click', function(e) {
-                        // Construct a template context object with the current msa
-                        // plus the values for the selected msa variables and render
-                        // all in the popup template
-                        var currentLayer = _.findWhere(TCVIZ.Config.MSA_layers, { value: valueField }),
-                            msaValues = e.layer.feature.properties,
-                            ctx = _.assign(msaValues, {
-                                selectedLayerDisplay: currentLayer.text,
-                                selectedLayerValue: msaValues[currentLayer.value],
-                            });
-
-                        e.layer
-                            .bindPopup(TCVIZ.Templates.tractPopup(ctx))
-                            .openPopup();
-                    });
+        TCVIZ.State.censusField = valueField;
+        TCVIZ.Connections.tractMap.getJson(valueField, msaId)
+            .done(function(data) {
+                data = removeNAs(data, valueField);
+                var layer = L.geoJson(data, {
+                    style: function(feature) {
+                        return stylePolygons(feature, valueField);
+                    }
                 });
-        }
+
+                layer.on('click', function(e) {
+                    // Construct a template context object with the current msa
+                    // plus the values for the selected msa variables and render
+                    // all in the popup template
+                    var currentLayer = _.findWhere(TCVIZ.Config.MSA_layers, { value: valueField }),
+                        msaValues = e.layer.feature.properties,
+                        ctx = _.assign(msaValues, {
+                            selectedLayerDisplay: currentLayer.text,
+                            selectedLayerValue: msaValues[currentLayer.value],
+                        });
+
+                    e.layer
+                        .bindPopup(TCVIZ.Templates.tractPopup(ctx))
+                        .openPopup();
+                });
+
+                updateMapLayer(layer);
+                setLegend(valueField);
+            });
     }
 
     /**
      * Set a nationwide point layer
      */
-    function setNationalGeoJSONLayer() {
-        var valueField = layerToggle.items[0];
-        if (valueField !== undefined) {
-            if (map.hasLayer(featureGroup)) {
-                map.removeLayer(featureGroup);
-            }
-            TCVIZ.State.ntdField = valueField;
-            TCVIZ.Connections.msaMap.getJson(valueField)
-                .done(function(data) {
-                    data = removeNAs(data, valueField);
-                    TCVIZ.State.sizeBreaks = getBreaks(data, sizeVar(valueField), 10);
-                    featureGroup = L.geoJson(data, {
-                        pointToLayer: function(feature, latlng) {
-                            return new L.CircleMarker(latlng,
-                                styleCircles(feature, valueField, TCVIZ.State.sizeBreaks)
-                            );
-                        }
-                    });
+    function setNationalGeoJSONLayer(layerId) {
+        if (!layerId) { return; }
+        var valueField = layerId;
 
-                    featureGroup.on('click', function(e) {
-                        // Construct a template context object with the current msa
-                        // plus the values for the selected msa variables and render
-                        // all in the popup template
-                        var currentLayer = _.findWhere(TCVIZ.Config.nationwide_layers, { value: valueField }),
-                            msaValues = e.layer.feature.properties,
-                            ctx = _.assign(msaValues, {
-                                selectedLayerDisplayChange: currentLayer.text,
-                                selectedLayerDisplayYear: currentLayer.id,
-                                selectedLayerValue: msaValues[currentLayer.value],
-                                selectedLayerValue2015: renderFormat(currentLayer.render, msaValues[sizeVar(currentLayer.value)])
-                            });
-
-                        e.layer
-                            .bindPopup(TCVIZ.Templates.msaPopup(ctx))
-                            .openPopup();
-                    });
-
-                    map.addLayer(featureGroup);
-                    setLegend(valueField);
+        TCVIZ.State.ntdField = valueField;
+        TCVIZ.Connections.msaMap.getJson(valueField)
+            .done(function(data) {
+                data = removeNAs(data, valueField);
+                TCVIZ.State.sizeBreaks = getBreaks(data, sizeVar(valueField), 10);
+                var layer = L.geoJson(data, {
+                    pointToLayer: function(feature, latlng) {
+                        return new L.CircleMarker(latlng,
+                            styleCircles(feature, valueField, TCVIZ.State.sizeBreaks)
+                        );
+                    }
                 });
-        }
+
+                layer.on('click', function(e) {
+                    // Construct a template context object with the current msa
+                    // plus the values for the selected msa variables and render
+                    // all in the popup template
+                    var currentLayer = _.findWhere(TCVIZ.Config.nationwide_layers, { value: valueField }),
+                        msaValues = e.layer.feature.properties,
+                        ctx = _.assign(msaValues, {
+                            selectedLayerDisplayChange: currentLayer.text,
+                            selectedLayerDisplayYear: currentLayer.id,
+                            selectedLayerValue: msaValues[currentLayer.value],
+                            selectedLayerValue2015: renderFormat(currentLayer.render, msaValues[sizeVar(currentLayer.value)])
+                        });
+
+                    e.layer
+                        .bindPopup(TCVIZ.Templates.msaPopup(ctx))
+                        .openPopup();
+                });
+
+                updateMapLayer(layer);
+                setLegend(valueField);
+            });
     }
 
     /**
@@ -446,25 +402,30 @@ $(document).ready(function() {
             });
     }
 
+    function updateMapLayer(layer) {
+        if (featureGroup) {
+            map.removeLayer(featureGroup);
+        }
+        featureGroup = layer;
+        map.addLayer(layer);
+    }
+
     /**
      * Set the default/stored map variable value for the current
      * zoom level
      */
-    function setMapDropdownValue() {
-        nationWide = isNationWide();
-        if (nationWide) {
-            if (TCVIZ.State.ntdField !== undefined) {
-                layerToggle.setValue(TCVIZ.State.ntdField);
-            } else {
-                layerToggle.setValue(TCVIZ.Config.defaultNtdField);
-            }
+    function updateMapDropdown() {
+        var layerValue;
+        if (isNationWide()) {
+            changeToggle(layerToggle, TCVIZ.Config.nationwide_layers);
+            layerValue = TCVIZ.State.ntdField || TCVIZ.Config.defaultNtdField;
+            TCVIZ.State.ntdField = layerToggle.items[0];
         } else {
-            if (TCVIZ.State.censusField !== undefined) {
-                layerToggle.setValue(TCVIZ.State.censusField);
-            } else {
-                layerToggle.setValue(TCVIZ.Config.defaultCensusField);
-            }
+            changeToggle(layerToggle, TCVIZ.Config.MSA_layers);
+            layerValue = TCVIZ.State.censusField || TCVIZ.Config.defaultCensusField;
+            TCVIZ.State.censusField = layerToggle.items[0];
         }
+        layerToggle.setValue(layerValue);
     }
 
     function sizeVar(variable) {
@@ -509,6 +470,10 @@ $(document).ready(function() {
             opacity: 0.5,
             fillOpacity: 0.6
         };
+    }
+
+    function isNationWide() {
+        return msaToggle.getValue() === TCVIZ.Config.defaultMSA;
     }
 
     /**

--- a/app/assets/js/src/tcviz-config.js
+++ b/app/assets/js/src/tcviz-config.js
@@ -8,7 +8,6 @@ TCVIZ.Config = {
         format: 'geojson',
         api_key: '73537cf8a5e88a4f170a0eda73deab782accaee2'
     },
-    zoomThreshold: 7,
     defaultNtdField: 'upt_total_c',
     defaultCensusField: 'pp_dn_c',
     defaultMSA: 'NNNNN',

--- a/app/assets/js/src/tcviz-state.js
+++ b/app/assets/js/src/tcviz-state.js
@@ -4,12 +4,5 @@ TCVIZ.State = {
      */
     ntdField: null,
     censusField: null,
-    currentMSA: null,
-    startNationWide: null,
-    // TODO: should the two objects below go in their own TCVIS objects?
-
-    /*
-    Time series object
-     */
-    timeSeries: null
+    sizeBreaks: null
 };


### PR DESCRIPTION
Significant refactor that attempts to clean up
handling of all user events.

Some improvements:
- Remove MSA/Nationwide layer switching on zoom level
  - Now tied only to:
    - Change in MSA toggle
    - Clicks on popup links
  - Indirectly fixes #82 since the layer switch is no
    longer tied to the zoom change
  - Allows removal of a significant amount of code
- Only remove the old layer immediately before adding
  the new one. Prevents race conditions where two
  layers could be added to the map
- Fix issue where MSA selection wouldn't switch properly
  when already at the tract level (#71)
- Refactors main.js map/toggle logic to tie state directly
  to the value set in the toggles, removing the global
  state that was unnecessarily duplicated since we can
  always just get the current layer/MSA state from the toggles
- Refactors map layer add/remove methods to take msaId and
  layerId as arguments, rather than pulling them within the
  functions. Makes code paths clearer.
- Updates setLegend calls so that the legend is updated only
  when the active layer is switched. Prevents new legend and
  layer from updating out of sync if layer load is slow.

## Testing

App should continue to function before, but better, as #71 and #82 should be fixed. Should also test that the layers are no longer swapped when the zoom threshold is crossed.

Open up the console and ensure that addLayer and removeLayer calls happen in sync, and that only one setGeoJSONLayer call happens per user interaction. We were firing the same events multiple times per interaction before.

Closes #71, Closes #82 